### PR TITLE
Fix env arg not being available at frontend build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        VITE_BACKEND_URL: ${VITE_BACKEND_URL}
     environment:
       API_HOST: backend
       API_PORT: 3001
@@ -16,7 +18,7 @@ services:
       - protocol: tcp
         published: 3000
         target: 80
-  
+
   # Gunicorn API server
   # - Most env vars are handled through Doppler
   # - A few are overridden though, such as DB_URL
@@ -44,6 +46,6 @@ services:
       - type: volume
         source: mariadb-data
         target: /var/lib/mysql
-  
+
 volumes:
   mariadb-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,6 +21,7 @@ RUN npm install
 COPY . .
 
 # Build
+ARG VITE_BACKEND_URL
 RUN npm run build
 
 #


### PR DESCRIPTION
See title. Sorry for no associated issue, this one just arose during integration testing.

## Problem

Frontend request would go to a bad endpoint, presumably because it was improperly formatted.

![image](https://user-images.githubusercontent.com/10553730/220240951-5620c8d4-d30b-42ba-9da8-ab6d24610cd1.png)

## Solution

Upon further inspection, @ingleanthony and I found that the env var for the backend url that was being used at build time by vite was inaccessible during the docker build process. Redefining the url env var as a build arg in docker resolved this behavior.

![image](https://user-images.githubusercontent.com/10553730/220241187-8f9f18c4-c37b-4a4d-9f39-17126d4ed4a2.png)
